### PR TITLE
tirpc: fix headers located inside include/tirpc

### DIFF
--- a/var/spack/repos/builtin/packages/libtirpc/package.py
+++ b/var/spack/repos/builtin/packages/libtirpc/package.py
@@ -53,3 +53,16 @@ class Libtirpc(AutotoolsPackage):
         if self.spec.satisfies("@1.3.3 platform=darwin"):
             return ["--disable-gssapi"]
         return []
+
+    @run_after("install")
+    def softlink_includes(self):
+        """Libtirpc installs its headers in a subdirectory of include.
+        Softlink them to the include directory so that packages that
+        expect to find rpc/rpc.h in include can find it."""
+
+        for header in os.listdir(self.prefix.include.tirpc):
+            src = join_path(self.prefix.include.tirpc, header)
+            dst = join_path(self.prefix.include, header)
+            if not os.path.exists(dst):
+                os.symlink(src, dst)
+


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
